### PR TITLE
Issue 3 | Handshake between sender & receiver 

### DIFF
--- a/Receiver/Receiver.java
+++ b/Receiver/Receiver.java
@@ -52,7 +52,43 @@ public class Receiver {
         System.out.println();
 
         // ----------------------------------------------------------------
-        // TODO Issue #3: Handshake (wait for SOT, reply ACK 0)
+        // Issue #3: Handshake (wait for SOT, reply ACK 0)
+        // ----------------------------------------------------------------
+        // tracks total ACKs sent - needed for ChaosEngine dropping logic later
+        int ackCount = 0;
+
+        byte[] rcvBuf = new byte[DSPacket.MAX_PACKET_SIZE];
+        DatagramPacket rcvDatagram = new DatagramPacket(rcvBuf, rcvBuf.length);
+
+        // block until we receive the sender's SOT
+        System.out.println("[Handshake] Waiting for SOT...");
+        socket.receive(rcvDatagram);
+        DSPacket sotPacket = new DSPacket(rcvDatagram.getData());
+
+        // validate it's the right packet
+        if (sotPacket.getType() != DSPacket.TYPE_SOT || sotPacket.getSeqNum() != 0) {
+            System.err.println("[Handshake] Expected SOT (Type=0, Seq=0), got Type="
+                    + sotPacket.getType() + " Seq=" + sotPacket.getSeqNum());
+            socket.close();
+            System.exit(1);
+        }
+        System.out.println("[Handshake] Received SOT (Seq=0)");
+
+        // send ACK 0 back to sender's ACK port
+        ackCount++;
+        DSPacket ackPacket = new DSPacket(DSPacket.TYPE_ACK, 0, null);
+        byte[] ackBytes = ackPacket.toBytes();
+        DatagramPacket ackDatagram = new DatagramPacket(ackBytes, ackBytes.length, senderAddress, senderAckPort);
+
+        // let ChaosEngine decide if this ACK gets dropped
+        if (!ChaosEngine.shouldDrop(ackCount, rn)) {
+            socket.send(ackDatagram);
+            System.out.println("[Handshake] Sent ACK (Seq=0) -- connection established");
+        } else {
+            System.out.println("[Handshake] ACK (Seq=0) dropped by ChaosEngine (ackCount=" + ackCount + ")");
+        }
+
+        // ----------------------------------------------------------------
         // TODO Issue #4: Stop-and-Wait data receive + teardown
         // TODO Issue #5: Go-Back-N data receive + teardown
         // TODO Issue #6: Integrate ChaosEngine ACK dropping

--- a/Sender/Sender.java
+++ b/Sender/Sender.java
@@ -72,7 +72,52 @@ public class Sender {
         System.out.println();
 
         // ----------------------------------------------------------------
-        // TODO Issue #3: Handshake (send SOT, wait for ACK 0)
+        // Issue #3: Handshake (send SOT, wait for ACK 0)
+        // ----------------------------------------------------------------
+        long startTime = System.currentTimeMillis(); // timer starts when we send SOT
+
+        // build the start-of-transmission packet
+        DSPacket sotPacket = new DSPacket(DSPacket.TYPE_SOT, 0, null);
+        byte[] sotBytes = sotPacket.toBytes();
+        DatagramPacket sotDatagram = new DatagramPacket(sotBytes, sotBytes.length, rcvAddress, rcvDataPort);
+
+        // buffer for the ACK response
+        byte[] ackBuf = new byte[DSPacket.MAX_PACKET_SIZE];
+        DatagramPacket ackDatagram = new DatagramPacket(ackBuf, ackBuf.length);
+
+        int timeoutCount = 0;
+        boolean handshakeDone = false;
+
+        // retry loop - keep sending SOT until we get ACK 0 or hit the 3-timeout limit
+        while (!handshakeDone) {
+            socket.send(sotDatagram);
+            System.out.println("[Handshake] Sent SOT (Seq=0)");
+
+            try {
+                socket.receive(ackDatagram);
+                DSPacket ack = new DSPacket(ackDatagram.getData());
+
+                // check if this is the ACK we're looking for
+                if (ack.getType() == DSPacket.TYPE_ACK && ack.getSeqNum() == 0) {
+                    System.out.println("[Handshake] Received ACK (Seq=0) -- connection established");
+                    handshakeDone = true;
+                } else {
+                    System.out.println("[Handshake] Unexpected packet (Type=" + ack.getType()
+                            + ", Seq=" + ack.getSeqNum() + "), ignoring...");
+                }
+            } catch (SocketTimeoutException e) {
+                timeoutCount++;
+                System.out.println("[Handshake] Timeout #" + timeoutCount + ", retransmitting SOT...");
+                // fail after 3 consecutive timeouts - can't establish connection
+                if (timeoutCount >= 3) {
+                    System.out.println("Unable to transfer file.");
+                    socket.close();
+                    System.exit(1);
+                }
+            }
+        }
+
+        // ----------------------------------------------------------------
         // TODO Issue #4: Stop-and-Wait data transfer + teardown
         // TODO Issue #5: Go-Back-N data transfer + teardown
         // TODO Issue #6: Integrate ChaosEngine packet reordering (GBN)


### PR DESCRIPTION
This pull request implements the handshake logic for establishing a connection between the sender and receiver in the data transfer protocol. The handshake ensures both sides are synchronized before any data transfer begins. The changes address Issue #3 by adding code to send and acknowledge a Start-of-Transmission (SOT) packet, with retry and validation logic.

Handshake implementation:

**Sender-side handshake logic (`Sender/Sender.java`):**
- Sends a SOT packet and waits for an ACK 0 response, retrying up to 3 times on timeout. If the correct ACK is received, the handshake is considered successful; otherwise, the process fails after 3 timeouts.

**Receiver-side handshake logic (`Receiver/Receiver.java`):**
- Waits for a SOT packet (Type=0, Seq=0) from the sender. Upon receiving and validating it, sends an ACK 0 back to the sender, using the ChaosEngine to possibly drop the ACK for testing. Tracks the number of ACKs sent for future ChaosEngine logic.

Closes #3 