### PR TITLE
Issue 4: Stop-and-Wait RDT 3.0 with timeout and teardown

### DIFF
--- a/Receiver/Receiver.java
+++ b/Receiver/Receiver.java
@@ -89,7 +89,68 @@ public class Receiver {
         }
 
         // ----------------------------------------------------------------
-        // TODO Issue #4: Stop-and-Wait data receive + teardown
+        // Issue #4: Stop-and-Wait data receive + teardown
+        // ----------------------------------------------------------------
+        FileOutputStream fos = new FileOutputStream(outputFile);
+        int expectedSeq = 1; // first DATA packet should be seq 1
+        int lastAckedSeq = 0; // last seq we ACKed (SOT was seq 0)
+
+        System.out.println("[S&W] Waiting for data...");
+
+        while (true) {
+            // fresh datagram each iteration so old data doesn't bleed through
+            rcvDatagram = new DatagramPacket(rcvBuf, rcvBuf.length);
+            socket.receive(rcvDatagram);
+            DSPacket pkt = new DSPacket(rcvDatagram.getData());
+
+            if (pkt.getType() == DSPacket.TYPE_DATA) {
+
+                if (pkt.getSeqNum() == expectedSeq) {
+                    // in-order packet - write it and advance expectedSeq
+                    fos.write(pkt.getPayload());
+                    System.out.println("[S&W] Received DATA Seq=" + pkt.getSeqNum()
+                            + " (" + pkt.getLength() + " bytes), ACKing");
+                    lastAckedSeq = expectedSeq;
+                    expectedSeq = (expectedSeq + 1) % 128;
+                } else {
+                    // duplicate or out-of-order - re-ACK the last good seq
+                    System.out.println("[S&W] Out-of-order Seq=" + pkt.getSeqNum()
+                            + ", re-ACKing Seq=" + lastAckedSeq);
+                }
+
+                // send ACK (whether in-order or duplicate)
+                ackCount++;
+                DSPacket reply = new DSPacket(DSPacket.TYPE_ACK, lastAckedSeq, null);
+                byte[] replyBytes = reply.toBytes();
+                DatagramPacket replyDg = new DatagramPacket(replyBytes, replyBytes.length, senderAddress,
+                        senderAckPort);
+                if (!ChaosEngine.shouldDrop(ackCount, rn)) {
+                    socket.send(replyDg);
+                } else {
+                    System.out.println("[S&W] ACK Seq=" + lastAckedSeq + " dropped by ChaosEngine");
+                }
+
+            } else if (pkt.getType() == DSPacket.TYPE_EOT) {
+                // teardown - ACK the EOT then break out
+                System.out.println("[Teardown] Received EOT Seq=" + pkt.getSeqNum());
+                ackCount++;
+                DSPacket reply = new DSPacket(DSPacket.TYPE_ACK, pkt.getSeqNum(), null);
+                byte[] replyBytes = reply.toBytes();
+                DatagramPacket replyDg = new DatagramPacket(replyBytes, replyBytes.length, senderAddress,
+                        senderAckPort);
+                if (!ChaosEngine.shouldDrop(ackCount, rn)) {
+                    socket.send(replyDg);
+                    System.out.println("[Teardown] Sent ACK for EOT -- closing");
+                } else {
+                    System.out.println("[Teardown] ACK for EOT dropped by ChaosEngine");
+                }
+                break;
+            }
+        }
+
+        fos.close();
+
+        // ----------------------------------------------------------------
         // TODO Issue #5: Go-Back-N data receive + teardown
         // TODO Issue #6: Integrate ChaosEngine ACK dropping
         // ----------------------------------------------------------------

--- a/Sender/Sender.java
+++ b/Sender/Sender.java
@@ -118,7 +118,99 @@ public class Sender {
         }
 
         // ----------------------------------------------------------------
-        // TODO Issue #4: Stop-and-Wait data transfer + teardown
+        // Issue #4: Stop-and-Wait data transfer + teardown
+        // ----------------------------------------------------------------
+        if (!useGBN) {
+
+            FileInputStream fis = new FileInputStream(file);
+            int seq = 1; // first DATA starts at seq 1 (SOT used seq 0)
+            timeoutCount = 0;
+
+            byte[] chunk = new byte[DSPacket.MAX_PAYLOAD_SIZE];
+            int bytesRead = fis.read(chunk);
+
+            // send one packet at a time and wait for its ACK
+            while (bytesRead != -1) {
+                byte[] payload = new byte[bytesRead];
+                System.arraycopy(chunk, 0, payload, 0, bytesRead);
+
+                DSPacket dataPacket = new DSPacket(DSPacket.TYPE_DATA, seq, payload);
+                byte[] dataBytes = dataPacket.toBytes();
+                DatagramPacket dataDatagram = new DatagramPacket(dataBytes, dataBytes.length, rcvAddress, rcvDataPort);
+
+                boolean acked = false;
+                while (!acked) {
+                    socket.send(dataDatagram);
+                    System.out.println("[S&W] Sent DATA Seq=" + seq + " (" + bytesRead + " bytes)");
+
+                    try {
+                        socket.receive(ackDatagram);
+                        DSPacket ack = new DSPacket(ackDatagram.getData());
+
+                        // check it's the ACK we're waiting for
+                        if (ack.getType() == DSPacket.TYPE_ACK && ack.getSeqNum() == seq) {
+                            System.out.println("[S&W] Got ACK Seq=" + seq);
+                            acked = true;
+                            timeoutCount = 0; // reset counter on progress
+                            seq = (seq + 1) % 128;
+                        } else {
+                            System.out.println("[S&W] Wrong ACK (got Seq=" + ack.getSeqNum() + "), retransmitting...");
+                        }
+                    } catch (SocketTimeoutException e) {
+                        timeoutCount++;
+                        System.out.println("[S&W] Timeout #" + timeoutCount + " on Seq=" + seq + ", retransmitting...");
+                        // 3 consecutive timeouts on the same packet - give up
+                        if (timeoutCount >= 3) {
+                            System.out.println("Unable to transfer file.");
+                            fis.close();
+                            socket.close();
+                            System.exit(1);
+                        }
+                    }
+                }
+
+                bytesRead = fis.read(chunk);
+            }
+
+            fis.close();
+
+            // teardown - send EOT and wait for its ACK
+            int eotSeq = seq; // seq already advanced past the last data packet
+            DSPacket eotPacket = new DSPacket(DSPacket.TYPE_EOT, eotSeq, null);
+            byte[] eotBytes = eotPacket.toBytes();
+            DatagramPacket eotDatagram = new DatagramPacket(eotBytes, eotBytes.length, rcvAddress, rcvDataPort);
+
+            timeoutCount = 0;
+            boolean eotAcked = false;
+            while (!eotAcked) {
+                socket.send(eotDatagram);
+                System.out.println("[Teardown] Sent EOT Seq=" + eotSeq);
+
+                try {
+                    socket.receive(ackDatagram);
+                    DSPacket ack = new DSPacket(ackDatagram.getData());
+
+                    if (ack.getType() == DSPacket.TYPE_ACK && ack.getSeqNum() == eotSeq) {
+                        System.out.println("[Teardown] Got ACK for EOT");
+                        eotAcked = true;
+                    }
+                } catch (SocketTimeoutException e) {
+                    timeoutCount++;
+                    System.out.println("[Teardown] Timeout #" + timeoutCount + " on EOT, retransmitting...");
+                    if (timeoutCount >= 3) {
+                        System.out.println("Unable to transfer file.");
+                        socket.close();
+                        System.exit(1);
+                    }
+                }
+            }
+
+            // print total time from SOT send to EOT ACK receipt
+            long elapsed = System.currentTimeMillis() - startTime;
+            System.out.printf("Total Transmission Time: %.2f seconds%n", elapsed / 1000.0);
+        }
+
+        // ----------------------------------------------------------------
         // TODO Issue #5: Go-Back-N data transfer + teardown
         // TODO Issue #6: Integrate ChaosEngine packet reordering (GBN)
         // ----------------------------------------------------------------


### PR DESCRIPTION
This pull request implements the Stop-and-Wait protocol for both the sender and receiver, covering data transfer and connection teardown. The changes add robust logic for reliable data transmission, including retransmission on timeout, proper sequence handling, and teardown acknowledgment.

Stop-and-Wait protocol implementation:

* Added Stop-and-Wait data transfer logic to `Sender/Sender.java`, including packet transmission, ACK handling, retransmission on timeout, and connection teardown with EOT packet and acknowledgment.
* Added Stop-and-Wait data receive logic to `Receiver/Receiver.java`, including in-order packet processing, duplicate/out-of-order handling, ACK sending, and teardown acknowledgment for EOT packets.

Closes #4 